### PR TITLE
Changes to allow dSentries to guard npc's as well as players.

### DIFF
--- a/dsentry.yml
+++ b/dsentry.yml
@@ -507,10 +507,10 @@ dsentry_task_attack:
         }
       }
     - define valid false
-    - if <npc.flag[dsentry.follow_target||null> matches player {
+    - if <npc.flag[dsentry.follow_target]||null> matches player {
       - if <npc.flag[dsentry.follow_target].as_player.is_online||false> define valid true
       }
-      else if <npc.flag[dsentry.follow_target||null> matches npc {
+      else if <npc.flag[dsentry.follow_target]||null> matches npc {
         - if <npc.flag[dsentry.follow_target].as_npc.is_spawned||false> define valid true
         }
     - if %valid% {


### PR DESCRIPTION
I haven't tested this extensively, but I have managed to setup one npc that is guarding me, and another npc that is guarding my guard.  When I move, the first npc follows me, and the second follows the first.  no errors apparent on console, even with debug on. (well one minor error complaining that the npc target is not a valid player, in the if command at the new line 507.)

I also updated a few .flag[] to .has_flag[] where it seemed appropriate.
